### PR TITLE
feat: add systemd socket activation handling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dcos/docs-ui-update-service
 require (
 	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
 	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
+	github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d
 	github.com/gorilla/mux v1.6.2
 	github.com/ivpusic/go-clicolor v0.0.0-20150828210804-23f0b77f328a // indirect
 	github.com/ivpusic/golog v0.0.0-20170608213328-28640bee649f // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d h1:t5Wuyh53qYyg9eqn4BbnlIT+vmhyww0TatL+zT3uWgI=
+github.com/coreos/go-systemd v0.0.0-20181012123002-c6f51f82210d/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/gorilla/mux v1.6.2 h1:Pgr17XVTNXAk3q/r4CpKzC5xBM/qW1uVLV+IhRZpIIk=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/ivpusic/go-clicolor v0.0.0-20150828210804-23f0b77f328a h1:C719vWPNIn8w0UnivhhvfIge00brg2r5BsCBmZmSWGo=


### PR DESCRIPTION
This adds the feature to the service to work together with the systemd socket activation. This
should use the provided address or start a new socket.

## Testing
start the service with `make start`,

and run in another session: `docker exec -it dcos-ui-service curl --unix-socket /run/dcos/dcos-ui-update-service.sock http://localhost/` this should give you a `404 page not found`,
`docker exec -it dcos-ui-service curl --unix-socket /run/dcos/dcos-ui-update-service.sock http://localhost/static/` this should give you a html file containing a `h1` which contains `test`
`docker exec -it dcos-ui-service curl -I --unix-socket /run/dcos/dcos-ui-update-service.sock http://localhost/api/v1/` this should give you ```HTTP/1.1 501 Not Implemented```


## Trade-offs

I am not sure :/