### PR TITLE
[DCOS-44681] move all code to packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage.xml
 build/
 versions/
 dcos-ui-update-service
+application-build-*

--- a/cosmos/client_test.go
+++ b/cosmos/client_test.go
@@ -1,4 +1,4 @@
-package main
+package cosmos
 
 import (
 	"encoding/json"
@@ -34,9 +34,9 @@ var (
 	}}`
 )
 
-func makeTestClient(server *httptest.Server) *CosmosClient {
+func makeTestClient(server *httptest.Server) *Client {
 	cosmosURL, _ := url.Parse(server.URL)
-	return NewCosmosClient(our_http.NewClient(server.Client()), cosmosURL)
+	return NewClient(our_http.NewClient(server.Client()), cosmosURL)
 }
 
 func serveSuccessfulListVersionResponseTestServer(t *testing.T) *httptest.Server {

--- a/dcos/dcos.go
+++ b/dcos/dcos.go
@@ -1,4 +1,4 @@
-package main
+package dcos
 
 import (
 	"fmt"

--- a/dcos/dcos_test.go
+++ b/dcos/dcos_test.go
@@ -1,4 +1,4 @@
-package main
+package dcos
 
 import (
 	"strings"
@@ -12,7 +12,7 @@ func TestDCOS(t *testing.T) {
 		// TODO: move to table driven tests
 		t.Run("throws if the file is not found", func(t *testing.T) {
 			system := DCOS{
-				MasterCountLocation: "fixtures/non-existant",
+				MasterCountLocation: "../fixtures/non-existant",
 			}
 
 			result, err := system.IsMultiMaster()
@@ -27,7 +27,7 @@ func TestDCOS(t *testing.T) {
 
 		t.Run("throws if the file is empty", func(t *testing.T) {
 			system := DCOS{
-				MasterCountLocation: "fixtures/empty",
+				MasterCountLocation: "../fixtures/empty",
 			}
 
 			result, err := system.IsMultiMaster()
@@ -42,7 +42,7 @@ func TestDCOS(t *testing.T) {
 
 		t.Run("returns true if there is a number bigger than 1", func(t *testing.T) {
 			system := DCOS{
-				MasterCountLocation: "fixtures/multi-master",
+				MasterCountLocation: "../fixtures/multi-master",
 			}
 
 			result, err := system.IsMultiMaster()
@@ -57,7 +57,7 @@ func TestDCOS(t *testing.T) {
 
 		t.Run("returns false if there is only one master", func(t *testing.T) {
 			system := DCOS{
-				MasterCountLocation: "fixtures/single-master",
+				MasterCountLocation: "../fixtures/single-master",
 			}
 
 			result, err := system.IsMultiMaster()

--- a/fileHandler/uiFileHandler.go
+++ b/fileHandler/uiFileHandler.go
@@ -1,4 +1,4 @@
-package main
+package fileHandler
 
 import (
 	"net/http"

--- a/fileHandler/uiFileHandler_test.go
+++ b/fileHandler/uiFileHandler_test.go
@@ -1,4 +1,4 @@
-package main
+package fileHandler
 
 import (
 	"io/ioutil"
@@ -11,7 +11,7 @@ import (
 
 func TestUIFileHandler(t *testing.T) {
 	t.Run("serves static files", func(t *testing.T) {
-		handler := NewUIFileHandler("/static/", "./public")
+		handler := NewUIFileHandler("/static/", "../public")
 
 		req, err := http.NewRequest("GET", "/static/", nil)
 		if err != nil {
@@ -34,7 +34,7 @@ func TestUIFileHandler(t *testing.T) {
 	})
 
 	t.Run("Can change documentRoot at runtime", func(t *testing.T) {
-		handler := NewUIFileHandler("/static/", "./public")
+		handler := NewUIFileHandler("/static/", "../public")
 
 		req1, err := http.NewRequest("GET", "/static/test.html", nil)
 		if err != nil {
@@ -49,7 +49,7 @@ func TestUIFileHandler(t *testing.T) {
 				status, http.StatusNotFound)
 		}
 
-		err = handler.UpdateDocumentRoot("./testdata/docroot/public")
+		err = handler.UpdateDocumentRoot("../testdata/docroot/public")
 		if err != nil {
 			t.Errorf("UpdateDocumentRoot returned an err when expecting nil, %v", err)
 		}
@@ -82,7 +82,7 @@ func TestUIFileHandler(t *testing.T) {
 	})
 
 	t.Run("Can change documentRoot at runtime", func(t *testing.T) {
-		handler := NewUIFileHandler("/static/", "./public")
+		handler := NewUIFileHandler("/static/", "../public")
 		err := handler.UpdateDocumentRoot("./does-not-exist")
 		if !os.IsNotExist(err) {
 			t.Errorf("expected UpdateDocumentRoot to return NotExist err, instead got %v", err)
@@ -91,7 +91,7 @@ func TestUIFileHandler(t *testing.T) {
 
 	t.Run("GetAssetPrefix returns expected value", func(t *testing.T) {
 		expAssetPrefix := "/static/"
-		handler := NewUIFileHandler("/static/", "./public")
+		handler := NewUIFileHandler("/static/", "../public")
 		assetPrefix := handler.AssetPrefix()
 		if assetPrefix != expAssetPrefix {
 			t.Errorf("GetAssetPrefix returned %v, but expected %v", assetPrefix, expAssetPrefix)
@@ -99,8 +99,8 @@ func TestUIFileHandler(t *testing.T) {
 	})
 
 	t.Run("GetDocumentRoot returns expected value", func(t *testing.T) {
-		expDocRoot := "./public"
-		handler := NewUIFileHandler("/static/", "./public")
+		expDocRoot := "../public"
+		handler := NewUIFileHandler("/static/", "../public")
 		docRoot := handler.DocumentRoot()
 		if docRoot != expDocRoot {
 			t.Errorf("GetDocumentRoot returned %v, but expected %v", docRoot, expDocRoot)
@@ -108,14 +108,14 @@ func TestUIFileHandler(t *testing.T) {
 	})
 
 	t.Run("GetDocumentRoot returns expected value after update", func(t *testing.T) {
-		expDocRoot1 := "./public"
-		expDocRoot2 := "./testdata/docroot/public"
-		handler := NewUIFileHandler("/static/", "./public")
+		expDocRoot1 := "../public"
+		expDocRoot2 := "../testdata/docroot/public"
+		handler := NewUIFileHandler("/static/", "../public")
 		docRoot := handler.DocumentRoot()
 		if docRoot != expDocRoot1 {
 			t.Errorf("GetDocumentRoot returned %v, but expected %v", docRoot, expDocRoot1)
 		}
-		handler.UpdateDocumentRoot("./testdata/docroot/public")
+		handler.UpdateDocumentRoot("../testdata/docroot/public")
 		docRoot = handler.DocumentRoot()
 		if docRoot != expDocRoot2 {
 			t.Errorf("GetDocumentRoot returned %v, but expected %v", docRoot, expDocRoot2)

--- a/main_test.go
+++ b/main_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 
 	"github.com/dcos/dcos-ui-update-service/config"
+	"github.com/dcos/dcos-ui-update-service/dcos"
 	our_http "github.com/dcos/dcos-ui-update-service/http"
+	"github.com/dcos/dcos-ui-update-service/updateManager"
 	"github.com/spf13/afero"
 )
 
@@ -24,7 +26,7 @@ func setupUIService() *UIService {
 	cfg.VersionsRoot = "/ui-versions"
 	cfg.MasterCountFile = "./fixtures/single-master"
 
-	um, _ := NewUpdateManager(cfg, &our_http.Client{})
+	um, _ := updateManager.NewClient(cfg, &our_http.Client{})
 	um.Fs = afero.NewMemMapFs()
 	um.Fs.MkdirAll("/ui-versions", 0755)
 
@@ -34,7 +36,7 @@ func setupUIService() *UIService {
 		Config:        cfg,
 		UpdateManager: um,
 		UIHandler:     uiHandler,
-		MasterCounter: DCOS{
+		MasterCounter: dcos.DCOS{
 			MasterCountLocation: cfg.MasterCountFile,
 		},
 	}
@@ -151,7 +153,7 @@ func TestSetupUIHandler(t *testing.T) {
 		cfg.VersionsRoot = "/ui-versions"
 		cfg.MasterCountFile = "./fixtures/single-master"
 
-		um, _ := NewUpdateManager(cfg, &our_http.Client{})
+		um, _ := updateManager.NewClient(cfg, &our_http.Client{})
 		um.Fs = afero.NewMemMapFs()
 		um.Fs.MkdirAll("/ui-versions", 0755)
 
@@ -170,7 +172,7 @@ func TestSetupUIHandler(t *testing.T) {
 		cfg.VersionsRoot = "/ui-versions"
 		cfg.MasterCountFile = "./fixtures/single-master"
 
-		um, _ := NewUpdateManager(cfg, &our_http.Client{})
+		um, _ := updateManager.NewClient(cfg, &our_http.Client{})
 		um.Fs = afero.NewMemMapFs()
 		um.Fs.MkdirAll("/ui-versions/2.25.3", 0755)
 


### PR DESCRIPTION
Moved everything outside of main.go to package directories. This allows
better code separation for imports and testing.

## Testing

Run the tests: `go test ./...` or `make test`

Run the service locally: `make start` and make a request to `curl "http://127.0.0.1:5000/static/"`

## Trade-offs

`UIService` in `main.go` could still be pulled out into its own package. But planning to do that as a part of `multi-master` work directly.

## Dependencies

none