### PR TITLE
fix: serve versions from /dist subdir

### DIFF
--- a/updateManager/client.go
+++ b/updateManager/client.go
@@ -125,7 +125,7 @@ func (um *Client) PathToCurrentVersion() (string, error) {
 		return "", fmt.Errorf("there is no current version available")
 	}
 
-	versionPath := path.Join(um.VersionPath, currentVersion)
+	versionPath := path.Join(um.VersionPath, currentVersion, "dist")
 	return versionPath, nil
 }
 

--- a/updateManager/client_test.go
+++ b/updateManager/client_test.go
@@ -355,8 +355,8 @@ func TestClientPathToCurrentVersion(t *testing.T) {
 			t.Fatalf("Expected no error, got %#v", err)
 		}
 
-		if result != "/ui-versions/2.25.3" {
-			t.Fatalf("Expected result to be %q, got %q", "/ui-versions/2.25.3", result)
+		if result != "/ui-versions/2.25.3/dist" {
+			t.Fatalf("Expected result to be %q, got %q", "/ui-versions/2.25.3/dist", result)
 		}
 	})
 
@@ -450,7 +450,7 @@ func TestClientUpdateToVersion(t *testing.T) {
 		newVersionExists, err := afero.DirExists(fs, newVersionPath)
 
 		if !newVersionExists || err != nil {
-			t.Fatalf("Expected new directoy to exist, got %t, %#v", newVersionExists, err)
+			t.Fatalf("Expected new directory to exist, got %t, %#v", newVersionExists, err)
 		}
 
 		files, err := afero.ReadDir(fs, versionsPath)


### PR DESCRIPTION
Background: https://mesosphere.slack.com/archives/C03UXUVH7/p1542036869176300

This PR adds `/dist` slug to a version path. We need this because our Universe bundle archive contains the `dist` top directory. Which is generally a good thing to have your archive with a top directory.

## Trade-offs

Other rejected options:
1. Archiving files with no top-directory. Then having them unarchived one would end up with a bunch of files
2. Make the service to move the files after unarchiving. Rejected as less clean approach.