### PR TITLE
DCOS-46390 Abstraction to watch zk nodes

### DIFF
--- a/uiService/zkVersion.go
+++ b/uiService/zkVersion.go
@@ -129,7 +129,7 @@ func (zks *zkVersionStore) connectAndInitZKAsync(cfg *config.Config) {
 
 func (zks *zkVersionStore) initZKVersionStore(client zookeeper.ZKClient) {
 	zks.client = client
-	client.RegisterListener(func(state zookeeper.ClientState) {
+	client.RegisterListener("zk-version-store-version", func(state zookeeper.ClientState) {
 		go zks.handleZKStateChange(state)
 	})
 }

--- a/uiService/zkVersion.go
+++ b/uiService/zkVersion.go
@@ -10,7 +10,6 @@ import (
 	"github.com/dcos/dcos-ui-update-service/zookeeper"
 	"github.com/jpillora/backoff"
 	"github.com/pkg/errors"
-	"github.com/samuel/go-zookeeper/zk"
 	"github.com/sirupsen/logrus"
 )
 
@@ -23,19 +22,13 @@ type zkVersionStore struct {
 	zkClientState         zookeeper.ClientState
 	zkBasePath            string
 	versionPath           string
-	watchState            versionWatchState
+	zkPollingInterval     time.Duration
+	versionWatcher        zookeeper.ValueNodeWatcher
 }
 
 type zkUIVersion struct {
 	currentVersion UIVersion
 	initialized    bool
-	sync.Mutex
-}
-
-type versionWatchState struct {
-	active          bool
-	disconnected    chan struct{}
-	pollingInterval time.Duration
 	sync.Mutex
 }
 
@@ -58,12 +51,10 @@ func NewZKVersionStore(cfg *config.Config) VersionStore {
 			currentVersion: PreBundledUIVersion,
 			initialized:    false,
 		},
-		zkBasePath:  cfg.ZKBasePath(),
-		versionPath: makeVersionPath(cfg.ZKBasePath()),
-		watchState: versionWatchState{
-			active:          false,
-			pollingInterval: cfg.ZKPollingInterval(),
-		},
+		zkBasePath:        cfg.ZKBasePath(),
+		versionPath:       makeVersionPath(cfg.ZKBasePath()),
+		zkPollingInterval: cfg.ZKPollingInterval(),
+		versionWatcher:    nil,
 	}
 	go store.connectAndInitZKAsync(cfg)
 	return store
@@ -80,7 +71,7 @@ func (zks *zkVersionStore) UpdateCurrentVersion(newVersion UIVersion) error {
 		return ErrZookeeperNotConnected
 	}
 
-	err := zks.client.Set(zks.versionPath, []byte(newVersion))
+	_, err := zks.client.Set(zks.versionPath, []byte(newVersion))
 	if err != nil {
 		return errors.Wrap(err, "Failed to create version in ZK, not able to set the version node")
 	}
@@ -158,9 +149,6 @@ func (zks *zkVersionStore) handleZKStateChange(state zookeeper.ClientState) {
 	if oldState == zookeeper.Disconnected {
 		zks.initCurrentVersion()
 	}
-	if state == zookeeper.Disconnected && zks.watchState.active {
-		close(zks.watchState.disconnected)
-	}
 }
 
 func (zks *zkVersionStore) updateLocalCurrentVersion(version UIVersion) {
@@ -182,7 +170,7 @@ func (zks *zkVersionStore) updateLocalCurrentVersion(version UIVersion) {
 }
 
 func (zks *zkVersionStore) getVersionFromZK() (UIVersion, error) {
-	data, err := zks.client.Get(zks.versionPath)
+	data, _, err := zks.client.Get(zks.versionPath)
 	if err != nil {
 		return UIVersion(""), errors.Wrap(err, "unable to get version from zk")
 	}
@@ -193,7 +181,7 @@ func (zks *zkVersionStore) initCurrentVersion() {
 	var version UIVersion
 
 	log.Debug("Getting current ui version from ZK")
-	found, err := zks.client.Exists(zks.versionPath)
+	found, _, err := zks.client.Exists(zks.versionPath)
 	if err != nil {
 		panic(fmt.Sprintf("Error making exists check in zookeeper for ui version node @ '%v'. Error: %v", zks.versionPath, err.Error()))
 	}
@@ -213,7 +201,7 @@ func (zks *zkVersionStore) initCurrentVersion() {
 
 	zks.updateLocalCurrentVersion(version)
 
-	zks.startVersionWatch()
+	zks.createVersionWatcher()
 }
 
 func (zks *zkVersionStore) broadcastVersionChange() {
@@ -233,53 +221,25 @@ func (zks *zkVersionStore) broadcastVersionChange() {
 	}
 }
 
-func (zks *zkVersionStore) startVersionWatch() {
-	if zks.watchState.active {
-		log.Warning("Tried to start version watch while old watch was active")
+func (zks *zkVersionStore) createVersionWatcher() {
+	if zks.versionWatcher != nil {
 		return
 	}
 
-	zks.watchState.Lock()
-	defer zks.watchState.Unlock()
-	zks.watchState.active = true
-	zks.watchState.disconnected = make(chan struct{})
-
-	log.Debug("Version watch started")
-	go zks.pollForVersionChanges()
-}
-
-func (zks *zkVersionStore) stopVersionWatch() {
-	if !zks.watchState.active {
-		log.Warning("Tried to stop version watch with no watch active")
+	watcher, err := zookeeper.CreateValueNodeWatcher(zks.client, zks.versionPath, zks.zkPollingInterval, zks.versionWatcherCallback)
+	if err != nil {
+		// handle error
+		log.WithError(err).Warn("Failed to create ZK node watcher")
 		return
 	}
-	zks.watchState.Lock()
-	defer zks.watchState.Unlock()
-	zks.watchState.active = false
-	zks.watchState.disconnected = nil
-
-	log.Debug("Version watch stopped")
+	zks.versionWatcher = watcher
 }
 
-func (zks *zkVersionStore) pollForVersionChanges() {
-	for {
-		select {
-		case <-zks.watchState.disconnected:
-			zks.stopVersionWatch()
-		case <-time.After(zks.watchState.pollingInterval):
-			version, err := zks.getVersionFromZK()
-			switch err {
-			case nil:
-				currentVersion := zks.localVersion()
-				if version != currentVersion {
-					zks.updateLocalCurrentVersion(version)
-				}
-			case zk.ErrNoNode:
-				log.Error("Version node not found in ZK (was deleted?)")
-			default:
-				log.WithError(err).Error("Version poll get from zk failed.")
-			}
-		}
+func (zks *zkVersionStore) versionWatcherCallback(data []byte) {
+	version := UIVersion(data)
+	currentVersion := zks.localVersion()
+	if version != currentVersion {
+		zks.updateLocalCurrentVersion(version)
 	}
 }
 

--- a/zookeeper/fake_client.go
+++ b/zookeeper/fake_client.go
@@ -1,8 +1,9 @@
 package zookeeper
 
 import (
-	"github.com/samuel/go-zookeeper/zk"
 	"sync"
+
+	"github.com/samuel/go-zookeeper/zk"
 )
 
 type FakeZKClient struct {

--- a/zookeeper/fake_client.go
+++ b/zookeeper/fake_client.go
@@ -14,7 +14,6 @@ type FakeZKClient struct {
 	ChildrenError error
 
 	ClientStateResult ClientState
-	Listeners         []StateListener
 	IDListeners       map[string]StateListener
 	ExistsResult      bool
 	GetResult         []byte
@@ -41,12 +40,7 @@ func (zkc *FakeZKClient) ClientState() ClientState {
 	return zkc.ClientStateResult
 }
 
-func (zkc *FakeZKClient) RegisterListener(listener StateListener) {
-	zkc.Listeners = append(zkc.Listeners, listener)
-	listener(zkc.ClientStateResult)
-}
-
-func (zkc *FakeZKClient) RegisterListenerWithID(id string, listener StateListener) {
+func (zkc *FakeZKClient) RegisterListener(id string, listener StateListener) {
 	zkc.IDListeners[id] = listener
 	listener(zkc.ClientStateResult)
 }
@@ -57,9 +51,6 @@ func (zkc *FakeZKClient) UnregisterListener(id string) {
 
 func (zkc *FakeZKClient) PublishStateChange(newState ClientState) {
 	zkc.ClientStateResult = newState
-	for _, l := range zkc.Listeners {
-		l(newState)
-	}
 	for _, l := range zkc.IDListeners {
 		l(newState)
 	}

--- a/zookeeper/fake_client.go
+++ b/zookeeper/fake_client.go
@@ -1,0 +1,128 @@
+package zookeeper
+
+import (
+	"github.com/samuel/go-zookeeper/zk"
+)
+
+type FakeZKClient struct {
+	ExistsError   error
+	GetError      error
+	CreateError   error
+	SetError      error
+	ChildrenError error
+
+	ClientStateResult ClientState
+	Listeners         []StateListener
+	IDListeners       map[string]StateListener
+	ExistsResult      bool
+	GetResult         []byte
+	GetResults        [][]byte
+	GetResultsIndex   int
+	ChildrenResults   []string
+	EventChannel      chan zk.Event
+
+	CreateCall func(string, []byte, []int32)
+	SetCall    func(string, []byte)
+}
+
+func NewFakeZKClient() *FakeZKClient {
+	return &FakeZKClient{
+		IDListeners:  make(map[string]StateListener),
+		EventChannel: make(chan zk.Event, 1),
+	}
+}
+
+func (zkc *FakeZKClient) Close() {}
+
+func (zkc *FakeZKClient) ClientState() ClientState {
+	return zkc.ClientStateResult
+}
+
+func (zkc *FakeZKClient) RegisterListener(listener StateListener) {
+	zkc.Listeners = append(zkc.Listeners, listener)
+	listener(zkc.ClientStateResult)
+}
+
+func (zkc *FakeZKClient) RegisterListenerWithID(id string, listener StateListener) {
+	zkc.IDListeners[id] = listener
+	listener(zkc.ClientStateResult)
+}
+
+func (zkc *FakeZKClient) UnregisterListener(id string) {
+	delete(zkc.IDListeners, id)
+}
+
+func (zkc *FakeZKClient) PublishStateChange(newState ClientState) {
+	zkc.ClientStateResult = newState
+	for _, l := range zkc.Listeners {
+		l(newState)
+	}
+	for _, l := range zkc.IDListeners {
+		l(newState)
+	}
+}
+
+func (zkc *FakeZKClient) Exists(path string) (bool, int32, error) {
+	if zkc.ExistsError != nil {
+		return false, -1, zkc.ExistsError
+	}
+	return zkc.ExistsResult, 0, nil
+}
+
+func (zkc *FakeZKClient) existsW(path string) (bool, int32, <-chan zk.Event, error) {
+	found, ver, err := zkc.Exists(path)
+	return found, ver, zkc.EventChannel, err
+}
+
+func (zkc *FakeZKClient) Get(path string) ([]byte, int32, error) {
+	if zkc.GetError != nil {
+		return nil, -1, zkc.GetError
+	}
+	numGetResults := len(zkc.GetResults)
+	if numGetResults > 0 {
+		resultIndex := zkc.GetResultsIndex
+		result := zkc.GetResults[resultIndex]
+		if zkc.GetResultsIndex < (numGetResults - 1) {
+			zkc.GetResultsIndex++
+		}
+		return result, int32(resultIndex), nil
+	}
+	return zkc.GetResult, 0, nil
+}
+
+func (zkc *FakeZKClient) getW(path string) ([]byte, int32, <-chan zk.Event, error) {
+	val, ver, err := zkc.Get(path)
+	return val, ver, zkc.EventChannel, err
+}
+
+func (zkc *FakeZKClient) Create(path string, data []byte, perms []int32) error {
+	if zkc.CreateCall != nil {
+		zkc.CreateCall(path, data, perms)
+	}
+	if zkc.CreateError != nil {
+		return zkc.CreateError
+	}
+	return nil
+}
+
+func (zkc *FakeZKClient) Set(path string, data []byte) (int32, error) {
+	if zkc.SetCall != nil {
+		zkc.SetCall(path, data)
+	}
+	if zkc.SetError != nil {
+		return -1, zkc.SetError
+	}
+	return 0, nil
+}
+
+func (zkc *FakeZKClient) Children(path string) ([]string, int32, error) {
+	if zkc.ChildrenError != nil {
+		return nil, -1, zkc.ChildrenError
+	}
+	return zkc.ChildrenResults, 0, nil
+}
+
+func (zkc *FakeZKClient) childrenW(path string) ([]string, int32, <-chan zk.Event, error) {
+	val, ver, err := zkc.Children(path)
+	return val, ver, zkc.EventChannel, err
+}

--- a/zookeeper/node_watcher.go
+++ b/zookeeper/node_watcher.go
@@ -1,0 +1,56 @@
+package zookeeper
+
+import (
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+var (
+	// ErrListenerNotProvided error if Create watcher function given a nil listener
+	ErrListenerNotProvided = errors.New("A listener callback must be provided to create a node watcher")
+	// ErrDisconnected if you attempt to create a watcher while ZK is disconnected
+	ErrDisconnected = errors.New("ZK connection is current disconnected, cannot create a node watcher")
+	// ErrNodeDoesNotExist if you attempt to create a ParentNodeWatcher for a node that does not exist
+	ErrNodeDoesNotExist = errors.New("The node must exist to create a ParentNodeWatcher")
+	// ErrFailedToReadNode if the given node cannot be read
+	ErrFailedToReadNode = errors.New("Failed to read node from ZK")
+)
+
+type ParentNodeWatcher interface {
+	Children() []string
+	Path() string
+	Close()
+}
+
+type ValueNodeWatcher interface {
+	Value() []byte
+	Path() string
+	Close()
+}
+
+// CreateParentNodeWatcher returns a ZK ParentNodeWatcher that will call the provided listener when the children of the node are modified.
+// Will poll the node for changes with the default watcherPollTimeout
+func CreateParentNodeWatcher(client ZKClient, path string, pollTimeout time.Duration, listener ParentNodeWatchListener) (ParentNodeWatcher, error) {
+	if listener == nil {
+		return nil, ErrListenerNotProvided
+	}
+	// Ensure client is currently connected, otherwise error
+	if client.ClientState() == Disconnected {
+		return nil, ErrDisconnected
+	}
+	return createParentWatcher(client, path, pollTimeout, listener)
+}
+
+// CreateValueNodeWatcher returns a ZK ValueNodeWatcher that will call the provided listener when the node value changes, is created or deleted.
+// Will poll the node for changes with the default watcherPollTimeout
+func CreateValueNodeWatcher(client ZKClient, path string, pollTimeout time.Duration, listener ValueNodeWatchListener) (ValueNodeWatcher, error) {
+	if listener == nil {
+		return nil, ErrListenerNotProvided
+	}
+	// Ensure client is currently connected, otherwise error
+	if client.ClientState() == Disconnected {
+		return nil, ErrDisconnected
+	}
+	return createValueWatcher(client, path, pollTimeout, listener)
+}

--- a/zookeeper/node_watcher.go
+++ b/zookeeper/node_watcher.go
@@ -1,8 +1,6 @@
 package zookeeper
 
 import (
-	"time"
-
 	"github.com/pkg/errors"
 )
 
@@ -27,30 +25,4 @@ type ValueNodeWatcher interface {
 	Value() []byte
 	Path() string
 	Close()
-}
-
-// CreateParentNodeWatcher returns a ZK ParentNodeWatcher that will call the provided listener when the children of the node are modified.
-// Will poll the node for changes with the default watcherPollTimeout
-func CreateParentNodeWatcher(client ZKClient, path string, pollTimeout time.Duration, listener ParentNodeWatchListener) (ParentNodeWatcher, error) {
-	if listener == nil {
-		return nil, ErrListenerNotProvided
-	}
-	// Ensure client is currently connected, otherwise error
-	if client.ClientState() == Disconnected {
-		return nil, ErrDisconnected
-	}
-	return createParentWatcher(client, path, pollTimeout, listener)
-}
-
-// CreateValueNodeWatcher returns a ZK ValueNodeWatcher that will call the provided listener when the node value changes, is created or deleted.
-// Will poll the node for changes with the default watcherPollTimeout
-func CreateValueNodeWatcher(client ZKClient, path string, pollTimeout time.Duration, listener ValueNodeWatchListener) (ValueNodeWatcher, error) {
-	if listener == nil {
-		return nil, ErrListenerNotProvided
-	}
-	// Ensure client is currently connected, otherwise error
-	if client.ClientState() == Disconnected {
-		return nil, ErrDisconnected
-	}
-	return createValueWatcher(client, path, pollTimeout, listener)
 }

--- a/zookeeper/parent_node_watcher.go
+++ b/zookeeper/parent_node_watcher.go
@@ -1,0 +1,252 @@
+package zookeeper
+
+import (
+	"time"
+
+	"github.com/jpillora/backoff"
+	"github.com/samuel/go-zookeeper/zk"
+	"github.com/sirupsen/logrus"
+)
+
+// ParentNodeWatchListener function signature for parent node watcher listner, this is used to invoke a callback when a ZK node changes
+type ParentNodeWatchListener func([]string)
+
+type parentNodeWatcher struct {
+	client       ZKClient
+	nodePath     string
+	pollTimeout  time.Duration
+	lastVersion  int32
+	children     []string
+	eventChannel <-chan zk.Event
+	disconnected chan struct{}
+	closed       chan struct{}
+	listener     ParentNodeWatchListener
+	watchActive  bool
+	log          *logrus.Entry
+}
+
+func (nw *parentNodeWatcher) Children() []string {
+	return nw.children
+}
+
+func (nw *parentNodeWatcher) Path() string {
+	return nw.nodePath
+}
+
+func (nw *parentNodeWatcher) Close() {
+	close(nw.closed)
+	nw.client.UnregisterListener(nw.nodePath)
+}
+
+func createParentWatcher(client ZKClient, path string, polltimeout time.Duration, listener ParentNodeWatchListener) (ParentNodeWatcher, error) {
+	// For parent node ensure it exists
+	exists, _, err := client.Exists(path)
+	if err != nil {
+		return nil, ErrFailedToReadNode
+	}
+	if !exists {
+		return nil, ErrNodeDoesNotExist
+	}
+
+	// Get current value
+	children, ver, err := client.Children(path)
+	if err != nil {
+		return nil, ErrFailedToReadNode
+	}
+
+	nw := &parentNodeWatcher{
+		client:       client,
+		nodePath:     path,
+		pollTimeout:  polltimeout,
+		lastVersion:  ver,
+		children:     children,
+		eventChannel: nil,
+		disconnected: nil,
+		closed:       make(chan struct{}),
+		listener:     listener,
+		watchActive:  false,
+		log: logrus.WithFields(logrus.Fields{
+			"package": "zookeeper.parent_node_watcher",
+			"zk-node": path,
+		}),
+	}
+	nw.log.Debug("Parent watcher created.")
+	nw.log.Tracef("Parent poll timeout %d", int64(polltimeout))
+	client.RegisterListenerWithID(path, nw.handleZkStateChange)
+	return nw, nil
+}
+
+func (nw *parentNodeWatcher) handleZkStateChange(state ClientState) {
+	if state == Disconnected {
+		nw.log.Debug("ZK Disconnected, stopping node watcher")
+		close(nw.disconnected)
+		nw.disconnected = nil
+	}
+	if state == Connected {
+		if nw.disconnected == nil {
+			nw.disconnected = make(chan struct{})
+		}
+		if !nw.watchActive {
+			nw.log.Debug("ZK Connected, starting node watcher")
+			go nw.startWatch()
+		}
+	}
+}
+
+func (nw *parentNodeWatcher) startWatch() {
+	nw.log.Trace("Creating ZK eventChannel")
+	children, ver, eventChannel, err := nw.client.childrenW(nw.nodePath)
+	if err != nil {
+		nw.log.WithError(err).Warn("Unable to create ZK eventChannel, will retry")
+		go nw.restartWatchAfterError()
+		return
+	}
+	nw.handleChildrenReceived(children, ver)
+	nw.watchChannelCreated(eventChannel)
+}
+
+func (nw *parentNodeWatcher) watchChannelCreated(channel <-chan zk.Event) {
+	nw.log.Trace("ZK eventChannel created")
+	nw.eventChannel = channel
+	if !nw.watchActive {
+		nw.watchActive = true
+	}
+	nw.waitOrPoll()
+}
+
+func (nw *parentNodeWatcher) waitOrPoll() {
+	for {
+		nw.log.Trace("waiting for node event")
+		select {
+		// Node event received
+		case nodeEvent := <-nw.eventChannel:
+			nw.handleNodeEvent(nodeEvent)
+			return
+		// Connection disconnected
+		case <-nw.disconnected:
+			nw.handleDisconnected()
+			return
+		// Watch Closed
+		case <-nw.closed:
+			nw.handleClosed()
+			return
+		// Timeout and poll
+		case <-time.After(nw.pollTimeout):
+			nw.handlePollTimeout()
+		}
+	}
+}
+
+func (nw *parentNodeWatcher) restartWatchAfterError() {
+	nw.clearWatch()
+	b := &backoff.Backoff{
+		Min:    5 * time.Second,
+		Max:    5 * time.Minute,
+		Factor: 2,
+		Jitter: false,
+	}
+	for {
+		// Ensure we're connected, otherwise exit
+		if nw.client.ClientState() == Disconnected {
+			nw.log.Info("Exiting watch retry because ZK connection was lost")
+			return
+		}
+		children, stat, eventChannel, err := nw.client.childrenW(nw.nodePath)
+		if err == nil {
+			nw.handleChildrenReceived(children, stat)
+			nw.log.Info("Watch re-established after error")
+			nw.watchChannelCreated(eventChannel)
+			return
+		}
+		select {
+		case <-nw.disconnected:
+			nw.handleDisconnected()
+			return
+		case <-nw.closed:
+			nw.handleClosed()
+			return
+		case <-time.After(b.Duration()):
+			nw.log.Trace("Retrying to create watch after error")
+		}
+	}
+}
+
+func (nw *parentNodeWatcher) handlePollTimeout() {
+	nw.log.Debug("Timeout poll of value")
+	err := nw.getAndUpdateChildren()
+	if err != nil {
+		nw.log.WithError(err).Warn("Failed to get ZK node value when polling")
+	}
+}
+
+func (nw *parentNodeWatcher) handleDisconnected() {
+	nw.log.Debug("Lost ZK Connection")
+	nw.clearWatch()
+}
+
+func (nw *parentNodeWatcher) handleClosed() {
+	nw.log.Debug("Watcher closed")
+	nw.clearWatch()
+}
+
+func (nw *parentNodeWatcher) clearWatch() {
+	if nw.eventChannel != nil {
+		nw.eventChannel = nil
+	}
+	if nw.watchActive {
+		nw.watchActive = false
+	}
+}
+
+func (nw *parentNodeWatcher) handleNodeEvent(event zk.Event) {
+	if event.Err != nil {
+		nw.log.WithError(event.Err).Warn("Received error from ZK eventChannel")
+		go nw.restartWatchAfterError()
+		return
+	}
+	if event.State == zk.StateDisconnected {
+		nw.handleDisconnected()
+		return
+	}
+	go nw.startWatch()
+}
+
+func (nw *parentNodeWatcher) getAndUpdateChildren() error {
+	children, stat, err := nw.client.Children(nw.nodePath)
+	if err != nil {
+		return err
+	}
+	nw.handleChildrenReceived(children, stat)
+	return nil
+}
+
+func (nw *parentNodeWatcher) handleChildrenReceived(children []string, version int32) {
+	nw.log.WithField("zk-node-children", children).Trace("Received ZK Node Children")
+	if !childrenEqual(nw.children, children) || nw.lastVersion != version {
+		nw.children = children
+		nw.log.WithFields(
+			logrus.Fields{
+				"current-children":     nw.children,
+				"zk-node-children":     children,
+				"current-stat-version": nw.lastVersion,
+				"stat-version":         version,
+			},
+		).Debug("Executing listener callback")
+		go nw.listener(nw.children)
+	} else {
+		nw.log.Trace("Value matched current value")
+	}
+	nw.lastVersion = version
+}
+
+func childrenEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/zookeeper/parent_node_watcher.go
+++ b/zookeeper/parent_node_watcher.go
@@ -67,7 +67,7 @@ func CreateParentNodeWatcher(client ZKClient, path string, polltimeout time.Dura
 	}
 	nw.log.Debug("Parent watcher created.")
 	nw.log.Tracef("Parent poll timeout %d", int64(polltimeout))
-	client.RegisterListenerWithID(path, nw.handleZkStateChange)
+	client.RegisterListener(path, nw.handleZkStateChange)
 	return nw, nil
 }
 

--- a/zookeeper/parent_node_watcher_test.go
+++ b/zookeeper/parent_node_watcher_test.go
@@ -103,7 +103,10 @@ func TestParentNodeWatcher(t *testing.T) {
 			wg.Done()
 		})
 		defer watcher.Close()
+
+		client.Lock()
 		client.ChildrenResults = []string{"bar"}
+		client.Unlock()
 
 		listenerMutex.Lock()
 		client.EventChannel <- zk.Event{
@@ -143,7 +146,10 @@ func TestParentNodeWatcher(t *testing.T) {
 			wg.Done()
 		})
 		defer watcher.Close()
+
+		client.Lock()
 		client.ChildrenResults = []string{"bar"}
+		client.Unlock()
 
 		wg.Wait()
 
@@ -175,7 +181,9 @@ func TestParentNodeWatcher(t *testing.T) {
 			wg.Done()
 		})
 		defer watcher.Close()
+		client.Lock()
 		client.ChildrenResults = []string{"baz"}
+		client.Unlock()
 
 		listenerMutex.Lock()
 		client.EventChannel <- zk.Event{

--- a/zookeeper/parent_node_watcher_test.go
+++ b/zookeeper/parent_node_watcher_test.go
@@ -1,0 +1,198 @@
+package zookeeper
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/samuel/go-zookeeper/zk"
+
+	"github.com/dcos/dcos-ui-update-service/tests"
+)
+
+func TestParentNodeWatcher(t *testing.T) {
+	const (
+		pollTimeout      = time.Duration(30 * time.Second)
+		shortPollTimeout = time.Duration(500 * time.Millisecond)
+	)
+
+	t.Parallel()
+
+	t.Run("returns ErrListenerNotProvided if listener callback is nil", func(t *testing.T) {
+		client := NewFakeZKClient()
+
+		_, err := CreateParentNodeWatcher(client, "/foo", pollTimeout, nil)
+
+		tests.H(t).ErrEql(err, ErrListenerNotProvided)
+	})
+
+	t.Run("returns ErrDisconnected if client is Disconnected", func(t *testing.T) {
+		client := NewFakeZKClient()
+
+		_, err := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {})
+
+		tests.H(t).ErrEql(err, ErrDisconnected)
+	})
+
+	t.Run("returns ErrFailedToReadNode if Exists returns error while creating", func(t *testing.T) {
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsError = errors.New("Boom!!")
+
+		_, err := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {})
+
+		tests.H(t).ErrEql(err, ErrFailedToReadNode)
+	})
+
+	t.Run("returns ErrNodeDoesNotExist if Exists returns false", func(t *testing.T) {
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		_, err := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {})
+
+		tests.H(t).ErrEql(err, ErrNodeDoesNotExist)
+	})
+
+	t.Run("returns watcher if node exists", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.ChildrenResults = []string{}
+
+		watcher, err := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {})
+		defer watcher.Close()
+
+		helper.IsNil(err)
+		helper.NotNil(watcher)
+		helper.IntEql(len(watcher.Children()), 0)
+	})
+
+	t.Run("CreateParentNodeWatcher  sets polling timeout to value given", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.ChildrenResults = []string{}
+
+		watcher, _ := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {})
+		defer watcher.Close()
+
+		parentWatcher, _ := watcher.(*parentNodeWatcher)
+		helper.Int64Eql(parentWatcher.pollTimeout.Nanoseconds(), pollTimeout.Nanoseconds())
+	})
+
+	t.Run("Calls listener when NodeCreated event is received", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.ChildrenResults = []string{}
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		var listenerCalls [][]string
+		wg.Add(1)
+
+		watcher, _ := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+		client.ChildrenResults = []string{"bar"}
+
+		listenerMutex.Lock()
+		client.EventChannel <- zk.Event{
+			Type:  zk.EventNodeCreated,
+			Err:   nil,
+			State: zk.StateConnected,
+		}
+		listenerMutex.Unlock()
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+		helper.IntEql(len(listenerCalls), 1)
+		helper.IntEql(len(listenerCalls[0]), 1)
+		helper.StringEql(listenerCalls[0][0], "bar")
+		helper.IntEql(len(watcher.Children()), 1)
+		helper.StringEql(watcher.Children()[0], "bar")
+	})
+
+	t.Run("Calls listener when Children change after pollTimeout", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.ChildrenResults = []string{}
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		var listenerCalls [][]string
+		wg.Add(1)
+
+		watcher, _ := CreateParentNodeWatcher(client, "/foo", shortPollTimeout, func(val []string) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+		client.ChildrenResults = []string{"bar"}
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+		helper.IntEql(len(listenerCalls), 1)
+		helper.IntEql(len(listenerCalls[0]), 1)
+		helper.StringEql(listenerCalls[0][0], "bar")
+		helper.IntEql(len(watcher.Children()), 1)
+		helper.StringEql(watcher.Children()[0], "bar")
+	})
+
+	t.Run("Calls listener when NodeDeleted event is received", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.ChildrenResults = []string{"bar", "baz"}
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		var listenerCalls [][]string
+		wg.Add(1)
+
+		watcher, _ := CreateParentNodeWatcher(client, "/foo", pollTimeout, func(val []string) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+		client.ChildrenResults = []string{"baz"}
+
+		listenerMutex.Lock()
+		client.EventChannel <- zk.Event{
+			Type:  zk.EventNodeDeleted,
+			Err:   nil,
+			State: zk.StateConnected,
+		}
+		listenerMutex.Unlock()
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+		helper.IntEql(len(listenerCalls), 1)
+		helper.IntEql(len(listenerCalls[0]), 1)
+		helper.StringEql(listenerCalls[0][0], "baz")
+		helper.IntEql(len(watcher.Children()), 1)
+		helper.StringEql(watcher.Children()[0], "baz")
+	})
+}

--- a/zookeeper/value_node_watcher.go
+++ b/zookeeper/value_node_watcher.go
@@ -28,6 +28,8 @@ type valueNodeWatcher struct {
 }
 
 func (nw *valueNodeWatcher) Value() []byte {
+	nw.watchMutex.Lock()
+	defer nw.watchMutex.Unlock()
 	return nw.value
 }
 
@@ -287,8 +289,11 @@ func (nw *valueNodeWatcher) handleValueReceived(value []byte, version int32) {
 		nw.log.WithField("zk-node-value", "nil").Trace("Received ZK Node Value")
 	}
 
+	nw.watchMutex.Lock()
+	defer nw.watchMutex.Unlock()
 	if !bytes.Equal(nw.value, value) || nw.lastVersion != version {
 		nw.value = value
+
 		nw.log.WithFields(
 			logrus.Fields{
 				"current-value":        string(nw.value),

--- a/zookeeper/value_node_watcher.go
+++ b/zookeeper/value_node_watcher.go
@@ -68,7 +68,7 @@ func CreateValueNodeWatcher(client ZKClient, path string, polltimeout time.Durat
 	}
 	nw.log.Debug("Value watcher created.")
 	nw.log.Tracef("Value poll timeout %d", int64(polltimeout))
-	client.RegisterListenerWithID(path, nw.handleZkStateChange)
+	client.RegisterListener(path, nw.handleZkStateChange)
 	return nw, nil
 }
 

--- a/zookeeper/value_node_watcher.go
+++ b/zookeeper/value_node_watcher.go
@@ -1,0 +1,305 @@
+package zookeeper
+
+import (
+	"bytes"
+	"sync"
+	"time"
+
+	"github.com/jpillora/backoff"
+	"github.com/samuel/go-zookeeper/zk"
+	"github.com/sirupsen/logrus"
+)
+
+// ValueNodeWatchListener function signature for value node watcher listner, this is used to invoke a callback when a ZK node changes
+type ValueNodeWatchListener func([]byte)
+type valueNodeWatcher struct {
+	client       ZKClient
+	nodePath     string
+	pollTimeout  time.Duration
+	lastVersion  int32
+	value        []byte
+	eventChannel <-chan zk.Event
+	disconnected chan struct{}
+	closed       chan struct{}
+	listener     ValueNodeWatchListener
+	watchActive  bool
+	log          *logrus.Entry
+	watchMutex   sync.Mutex
+}
+
+func (nw *valueNodeWatcher) Value() []byte {
+	return nw.value
+}
+
+func (nw *valueNodeWatcher) Path() string {
+	return nw.nodePath
+}
+
+func (nw *valueNodeWatcher) Close() {
+	close(nw.closed)
+	nw.client.UnregisterListener(nw.nodePath)
+}
+
+func createValueWatcher(client ZKClient, path string, polltimeout time.Duration, listener ValueNodeWatchListener) (ValueNodeWatcher, error) {
+	exists, ver, err := client.Exists(path)
+	if err != nil {
+		return nil, ErrFailedToReadNode
+	}
+	var value []byte
+	if exists {
+		value, ver, err = client.Get(path)
+		if err != nil {
+			return nil, ErrFailedToReadNode
+		}
+	} else {
+		value = []byte{}
+	}
+
+	nw := &valueNodeWatcher{
+		client:       client,
+		nodePath:     path,
+		pollTimeout:  polltimeout,
+		lastVersion:  ver,
+		value:        value,
+		eventChannel: nil,
+		disconnected: nil,
+		closed:       make(chan struct{}),
+		listener:     listener,
+		watchActive:  false,
+		log: logrus.WithFields(logrus.Fields{
+			"package": "zookeeper.value_node_watcher",
+			"zk-node": path,
+		}),
+	}
+	nw.log.Debug("Value watcher created.")
+	nw.log.Tracef("Value poll timeout %d", int64(polltimeout))
+	client.RegisterListenerWithID(path, nw.handleZkStateChange)
+	return nw, nil
+}
+
+func (nw *valueNodeWatcher) handleZkStateChange(state ClientState) {
+	nw.watchMutex.Lock()
+	defer nw.watchMutex.Unlock()
+	if state == Disconnected {
+		nw.log.Debug("ZK Disconnected, stopping node watcher")
+		close(nw.disconnected)
+		nw.disconnected = nil
+	}
+	if state == Connected {
+		if nw.disconnected == nil {
+			nw.disconnected = make(chan struct{})
+		}
+		if !nw.watchActive {
+			nw.log.Debug("ZK Connected, starting node watcher")
+			go nw.startWatch()
+		}
+	}
+}
+
+func (nw *valueNodeWatcher) startWatch() {
+	nw.watchMutex.Lock()
+
+	nw.log.Trace("Creating ZK eventChannel")
+	_, _, eventChannel, err := nw.client.existsW(nw.nodePath)
+	if err != nil {
+		nw.log.WithError(err).Warn("Unable to create ZK eventChannel, will retry")
+		nw.watchMutex.Unlock()
+		go nw.restartWatchAfterError()
+		return
+	}
+	nw.eventChannel = eventChannel
+	if !nw.watchActive {
+		nw.watchActive = true
+	}
+	nw.watchMutex.Unlock()
+	nw.waitOrPoll()
+}
+
+func (nw *valueNodeWatcher) waitOrPoll() {
+	for {
+		nw.log.Trace("waiting for node event")
+		select {
+		// Node event received
+		case nodeEvent := <-nw.eventChannel:
+			nw.handleNodeEvent(nodeEvent)
+			return
+		// Connection disconnected
+		case <-nw.disconnected:
+			nw.handleDisconnected()
+			return
+		// Watch Closed
+		case <-nw.closed:
+			nw.handleClosed()
+			return
+		// Timeout and poll
+		case <-time.After(nw.pollTimeout):
+			nw.handlePollTimeout()
+		}
+	}
+}
+
+func (nw *valueNodeWatcher) clearWatch() {
+	if nw.eventChannel != nil {
+		nw.eventChannel = nil
+	}
+	if nw.watchActive {
+		nw.watchActive = false
+	}
+}
+
+func (nw *valueNodeWatcher) restartWatchAfterError() {
+	nw.clearWatch()
+	b := &backoff.Backoff{
+		Min:    5 * time.Second,
+		Max:    5 * time.Minute,
+		Factor: 2,
+		Jitter: false,
+	}
+	for {
+		// Ensure we're connected, otherwise exit
+		if nw.client.ClientState() == Disconnected {
+			nw.log.Info("Exiting watch retry because ZK connection was lost")
+			return
+		}
+		nw.watchMutex.Lock()
+		exists, ver, eventChannel, err := nw.client.existsW(nw.nodePath)
+		if err == nil {
+			if exists {
+				value, getVersion, err := nw.client.Get(nw.nodePath)
+				if err == nil {
+					nw.handleValueReceived(value, getVersion)
+				}
+			} else {
+				nw.handleValueReceived(nil, ver)
+			}
+			nw.log.Info("Watch re-established after error")
+			nw.eventChannel = eventChannel
+			nw.watchActive = true
+			nw.watchMutex.Unlock()
+			go nw.waitOrPoll()
+		}
+		nw.watchMutex.Unlock()
+		select {
+		case <-nw.disconnected:
+			nw.handleDisconnected()
+			return
+		case <-nw.closed:
+			nw.handleClosed()
+			return
+		case <-time.After(b.Duration()):
+			nw.log.Trace("Retrying to create watch after error")
+		}
+	}
+}
+
+func (nw *valueNodeWatcher) handlePollTimeout() {
+	nw.log.Debug("Timeout poll of value")
+	found, ver, err := nw.client.Exists(nw.nodePath)
+	if err != nil {
+		nw.log.WithError(err).Warn("Failed to check ZK node exists when polling")
+		return
+	}
+	if found {
+		err := nw.getAndUpdateValue()
+		if err != nil {
+			nw.log.WithError(err).Warn("Failed to get ZK node value when polling")
+		}
+	} else {
+		nw.handleValueReceived([]byte{}, ver)
+	}
+
+}
+
+func (nw *valueNodeWatcher) handleDisconnected() {
+	nw.log.Debug("Lost ZK Connection")
+	nw.clearWatch()
+}
+
+func (nw *valueNodeWatcher) handleClosed() {
+	nw.log.Debug("Watcher closed")
+	nw.clearWatch()
+}
+
+func (nw *valueNodeWatcher) handleNodeEvent(event zk.Event) {
+	if event.Err != nil {
+		nw.log.WithError(event.Err).Warn("Received error from ZK eventChannel")
+		go nw.restartWatchAfterError()
+		return
+	}
+	if event.State == zk.StateDisconnected {
+		nw.handleDisconnected()
+		return
+	}
+	nw.log.WithField("zk-node-event", event.Type.String()).Debug("Received ZK Node Event")
+	switch event.Type {
+	case zk.EventNodeCreated:
+		fallthrough
+	case zk.EventNodeDataChanged:
+		err := nw.getAndUpdateValue()
+		if err != nil {
+			nw.log.WithError(err).Warn("Error getting node value")
+			go nw.restartWatchAfterError()
+			return
+		}
+		go nw.startWatch()
+		return
+	case zk.EventNodeDeleted:
+		err := nw.handleNodeDeleted()
+		if err != nil {
+			go nw.restartWatchAfterError()
+			return
+		}
+		go nw.startWatch()
+		return
+	}
+}
+
+func (nw *valueNodeWatcher) getAndUpdateValue() error {
+	value, ver, err := nw.client.Get(nw.nodePath)
+	if err != nil {
+		return err
+	}
+	nw.handleValueReceived(value, ver)
+	return nil
+}
+
+func (nw *valueNodeWatcher) handleNodeDeleted() error {
+	exists, ver, err := nw.client.Exists(nw.nodePath)
+	if err != nil {
+		nw.log.WithError(err).Warn("Failed to check ZK node exists")
+		return err
+	}
+	if exists {
+		err = nw.getAndUpdateValue()
+		if err != nil {
+			nw.log.WithError(err).Warn("Error getting node value")
+		}
+		return err
+	}
+	nw.handleValueReceived([]byte{}, ver)
+	return nil
+}
+
+func (nw *valueNodeWatcher) handleValueReceived(value []byte, version int32) {
+	if value != nil {
+		nw.log.WithField("zk-node-value", string(value)).Trace("Received ZK Node Value")
+	} else {
+		nw.log.WithField("zk-node-value", "nil").Trace("Received ZK Node Value")
+	}
+
+	if !bytes.Equal(nw.value, value) || nw.lastVersion != version {
+		nw.value = value
+		nw.log.WithFields(
+			logrus.Fields{
+				"current-value":        string(nw.value),
+				"node-value":           string(value),
+				"current-stat-version": nw.lastVersion,
+				"stat-version":         version,
+			},
+		).Debug("Executing listener callback")
+		go nw.listener(nw.value)
+	} else {
+		nw.log.Trace("Value matched current value")
+	}
+	nw.lastVersion = version
+}

--- a/zookeeper/value_node_watcher_test.go
+++ b/zookeeper/value_node_watcher_test.go
@@ -102,8 +102,10 @@ func TestValueNodeWatcher(t *testing.T) {
 		})
 		defer watcher.Close()
 
+		client.Lock()
 		client.ExistsResult = true
 		client.GetResult = []byte("bar")
+		client.Unlock()
 
 		listenerMutex.Lock()
 		client.EventChannel <- zk.Event{
@@ -141,8 +143,10 @@ func TestValueNodeWatcher(t *testing.T) {
 		})
 		defer watcher.Close()
 
+		client.Lock()
 		client.ExistsResult = true
 		client.GetResult = []byte("bar")
+		client.Unlock()
 
 		wg.Wait()
 
@@ -204,12 +208,15 @@ func TestValueNodeWatcher(t *testing.T) {
 		var listenerMutex sync.Mutex
 		wg.Add(1)
 		var listenerCalls [][]byte
-		watcher, err := CreateValueNodeWatcher(client, "/foo", shortPollTimeout, func(val []byte) {
+		callback := func(val []byte) {
 			listenerMutex.Lock()
 			defer listenerMutex.Unlock()
 			listenerCalls = append(listenerCalls, val)
 			wg.Done()
-		})
+		}
+
+		watcher, err := CreateValueNodeWatcher(client, "/foo", shortPollTimeout, callback)
+
 		helper.IsNil(err)
 		defer watcher.Close()
 
@@ -243,8 +250,10 @@ func TestValueNodeWatcher(t *testing.T) {
 		})
 		defer watcher.Close()
 
+		client.Lock()
 		client.ExistsResult = false
 		client.GetResult = []byte{}
+		client.Unlock()
 
 		listenerMutex.Lock()
 		client.EventChannel <- zk.Event{
@@ -283,8 +292,10 @@ func TestValueNodeWatcher(t *testing.T) {
 		})
 		defer watcher.Close()
 
+		client.Lock()
 		client.ExistsResult = false
 		client.GetResult = []byte{}
+		client.Unlock()
 
 		wg.Wait()
 

--- a/zookeeper/value_node_watcher_test.go
+++ b/zookeeper/value_node_watcher_test.go
@@ -1,0 +1,298 @@
+package zookeeper
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/samuel/go-zookeeper/zk"
+
+	"github.com/dcos/dcos-ui-update-service/tests"
+)
+
+func TestValueNodeWatcher(t *testing.T) {
+	const (
+		pollTimeout      = time.Duration(30 * time.Second)
+		shortPollTimeout = time.Duration(500 * time.Millisecond)
+	)
+
+	t.Parallel()
+
+	t.Run("returns ErrListenerNotProvided if listener callback is nil", func(t *testing.T) {
+		client := NewFakeZKClient()
+
+		_, err := CreateValueNodeWatcher(client, "/foo", pollTimeout, nil)
+
+		tests.H(t).ErrEql(err, ErrListenerNotProvided)
+	})
+
+	t.Run("returns ErrDisconnected if client is Disconnected", func(t *testing.T) {
+		client := NewFakeZKClient()
+
+		_, err := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {})
+
+		tests.H(t).ErrEql(err, ErrDisconnected)
+	})
+
+	t.Run("returns ErrFailedToReadNode if Exists returns error while creating", func(t *testing.T) {
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsError = errors.New("Boom!!")
+
+		_, err := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {})
+
+		tests.H(t).ErrEql(err, ErrFailedToReadNode)
+	})
+
+	t.Run("returns Watcher even if node doesn't exist", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		watcher, err := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {})
+		defer watcher.Close()
+
+		helper.IsNil(err)
+		helper.NotNil(watcher)
+	})
+
+	t.Run("watcher initializes value to empty slice if Node doesn't exist", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		watcher, err := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {})
+		defer watcher.Close()
+
+		helper.IsNil(err)
+		helper.IntEql(len(watcher.Value()), 0)
+	})
+
+	t.Run("CreateValueNodeWatcher sets polling timeout to value given", func(t *testing.T) {
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {})
+		defer watcher.Close()
+
+		valueWatcher, _ := watcher.(*valueNodeWatcher)
+
+		tests.H(t).Int64Eql(valueWatcher.pollTimeout.Nanoseconds(), pollTimeout.Nanoseconds())
+	})
+
+	t.Run("Calls listener when Node is created", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+
+		client.ExistsResult = true
+		client.GetResult = []byte("bar")
+
+		listenerMutex.Lock()
+		client.EventChannel <- zk.Event{
+			Type:  zk.EventNodeCreated,
+			Err:   nil,
+			State: zk.StateConnected,
+		}
+		listenerMutex.Unlock()
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.StringEql(string(listenerCalls[0]), "bar")
+		helper.StringEql(string(watcher.Value()), "bar")
+	})
+
+	t.Run("Calls listener when Node value is changed PollTimeout", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = false
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", shortPollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+
+		client.ExistsResult = true
+		client.GetResult = []byte("bar")
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.StringEql(string(listenerCalls[0]), "bar")
+		helper.StringEql(string(watcher.Value()), "bar")
+	})
+
+	t.Run("Calls listener when Node value is changed Event", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.GetResults = append(client.GetResults, []byte("bar"))
+		client.GetResults = append(client.GetResults, []byte("baz"))
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+		helper.StringEql(string(watcher.Value()), "bar")
+
+		listenerMutex.Lock()
+		client.EventChannel <- zk.Event{
+			Type:  zk.EventNodeDataChanged,
+			Err:   nil,
+			State: zk.StateConnected,
+		}
+		listenerMutex.Unlock()
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.StringEql(string(listenerCalls[0]), "baz")
+	})
+
+	t.Run("Calls listener when Node value is changed PollTimeout", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.GetResults = append(client.GetResults, []byte("bar"))
+		client.GetResults = append(client.GetResults, []byte("baz"))
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, err := CreateValueNodeWatcher(client, "/foo", shortPollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		helper.IsNil(err)
+		defer watcher.Close()
+
+		helper.StringEql(string(watcher.Value()), "bar")
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.StringEql(string(listenerCalls[0]), "baz")
+	})
+
+	t.Run("Calls listener when Node is deleted", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.GetResult = []byte("bar")
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", pollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+
+		client.ExistsResult = false
+		client.GetResult = []byte{}
+
+		listenerMutex.Lock()
+		client.EventChannel <- zk.Event{
+			Type:  zk.EventNodeDeleted,
+			Err:   nil,
+			State: zk.StateConnected,
+		}
+		listenerMutex.Unlock()
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.IntEql(len(listenerCalls[0]), 0)
+		helper.IntEql(len(watcher.Value()), 0)
+	})
+
+	t.Run("Calls listener when Node is deleted PollTimeout", func(t *testing.T) {
+		helper := tests.H(t)
+		client := NewFakeZKClient()
+		client.ClientStateResult = Connected
+		client.ExistsResult = true
+		client.GetResult = []byte("bar")
+
+		var wg sync.WaitGroup
+		var listenerMutex sync.Mutex
+		wg.Add(1)
+		var listenerCalls [][]byte
+		watcher, _ := CreateValueNodeWatcher(client, "/foo", shortPollTimeout, func(val []byte) {
+			listenerMutex.Lock()
+			defer listenerMutex.Unlock()
+			listenerCalls = append(listenerCalls, val)
+			wg.Done()
+		})
+		defer watcher.Close()
+
+		client.ExistsResult = false
+		client.GetResult = []byte{}
+
+		wg.Wait()
+
+		listenerMutex.Lock()
+		defer listenerMutex.Unlock()
+
+		helper.IntEql(len(listenerCalls), 1)
+		helper.IntEql(len(listenerCalls[0]), 0)
+		helper.IntEql(len(watcher.Value()), 0)
+	})
+}


### PR DESCRIPTION
The main focus of this PR was to introduce the `ValueNodeWatcher` & `ParentNodeWatcher` abstractions to the `zookeeper` package. These will be used when resolving the update race-condition between masters.

To dog food at least one of these I replaced the polling logic that existed in `zkVersionStore` with a `ValueNodeWatcher`. I also introduced a `ParentNodeWatcher` during testing but removed before commiting this work.

The two watchers are similar but since they have different data (`[]byte` & `[]string`) and slightly different behavior they are separate implementations.

There are some changes to the `zookeeper` `client` to accommodate the watchers. But also the change to get the version before `Set` & `Delete` calls was made after reading and better understanding the `zookeeper` API docs.

## Testing

Tests
1. Run unit tests `go test -race ./...`

Running locally
1. Run the service locally `docker-compose up`
- You should see lots of `trace` logs related to the version watcher
2. Update the zookeeper node to a new value (2.24.4 & 2.37.0 are version that exist in default universe). I do this using a [node.js script](https://gist.github.com/TattdCodeMonkey/880c0826e060da007275ad532cf94d94). When running with docker the zookeeper server is available @ `localhost:2181` the version node is `/dcos/ui-update/version`
- You should see the change detected in the logs and an update triggered if the value is different. If you update to a package that exists the update should be successfully completed.

## Trade-offs



## Dependencies

N/A

## Screenshots

N/A
