### PR TITLE
[DCOS-50422] fix: clean orphaned versions of UI on startup, reset, and updating

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,11 @@ type Config struct {
 	viper *viper.Viper
 }
 
+var (
+	// ErrPotentiallyDangerousVersionsRoot occurs if the Configured VersionsRoot is not set or set to an empty string or "/"
+	ErrPotentiallyDangerousVersionsRoot = errors.New("potentially dangerous versions-root configuration")
+)
+
 // Default values for config files
 const (
 	defaultConfig             = ""
@@ -111,6 +116,16 @@ func NewDefaultConfig() *Config {
 	return defaults
 }
 
+func validateConfig(cfg *Config) error {
+	var err error
+
+	if len(cfg.VersionsRoot()) <= 1 {
+		err = ErrPotentiallyDangerousVersionsRoot
+	}
+
+	return err
+}
+
 // Parse parses configuration from CLI arguments, environment variables, or config file
 func Parse(args []string) (*Config, error) {
 	viper := viper.New()
@@ -133,7 +148,8 @@ func Parse(args []string) (*Config, error) {
 		}
 	}
 
-	return &Config{viper}, nil
+	result := &Config{viper}
+	return result, validateConfig(result)
 }
 
 // ConfigFilePath is the path of the config file to load config settings from

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -233,4 +233,10 @@ func TestConfig(t *testing.T) {
 		helper.IsNil(err)
 		helper.BoolEql(cfg.InitUIDistSymlink(), true)
 	})
+
+	t.Run("returns ErrPotentiallyDangerousVersionsRoot when versions-root is empty", func(t *testing.T) {
+		_, err := Parse([]string{"--" + optVersionsRoot, ""})
+		tests.H(t).NotNil(err)
+		tests.H(t).StringContains(err.Error(), "potentially dangerous versions-root")
+	})
 }

--- a/uiService/api_test.go
+++ b/uiService/api_test.go
@@ -48,6 +48,8 @@ func TestRouter(t *testing.T) {
 	})
 
 	t.Run("Reset to prebundled UI", func(t *testing.T) {
+		var removeAllCalled = false
+
 		req, err := http.NewRequest("DELETE", "/api/v1/reset/", nil)
 		if err != nil {
 			t.Fatal(err)
@@ -56,6 +58,10 @@ func TestRouter(t *testing.T) {
 		defer tearDown(t)
 		service := setupUIServiceWithVersion()
 		umDouble := UpdateManagerDouble()
+		umDouble.RemoveAllCall = func() error {
+			removeAllCalled = true
+			return nil
+		}
 		service.UpdateManager = umDouble
 
 		rr := httptest.NewRecorder()
@@ -65,6 +71,9 @@ func TestRouter(t *testing.T) {
 			t.Errorf("handler returned wrong status code: got %v want %v",
 				status, http.StatusOK)
 		}
+
+		tests.H(t).BoolEql(removeAllCalled, true)
+		println("Here")
 	})
 
 	t.Run("Version Update", func(t *testing.T) {

--- a/uiService/root.go
+++ b/uiService/root.go
@@ -54,6 +54,7 @@ func SetupService(cfg *config.Config) (*UIService, error) {
 
 	checkUIDistSymlink(cfg)
 	checkCurrentVersion(updateManager)
+	checkVersionsRoot(cfg)
 	err = deleteOrphanedVersions(cfg, updateManager)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to clean up unused versions")
@@ -171,7 +172,7 @@ func handleVersionChange(service *UIService, newVersion string) {
 				return
 			}
 
-			err = service.UpdateManager.RemoveVersion(currentLocalVersion)
+			err = service.UpdateManager.RemoveAllVersionsExcept("")
 			if err != nil {
 				logrus.WithError(err).Error("Failed to removed current version when reseting to default document root.")
 				return

--- a/uiService/root_test.go
+++ b/uiService/root_test.go
@@ -72,14 +72,14 @@ func setupUIServiceWithVersion() *UIService {
 
 func TestVersionChange(t *testing.T) {
 	t.Run("Reset if new version is empty", func(t *testing.T) {
-		var resetCalled, updateCalled bool
+		var removeAllCalled, updateCalled bool
 		defer tearDown(t)
 		service := setupTestUIService()
 
 		um := UpdateManagerDouble()
 		um.VersionResult = "2.24.4"
-		um.ResetCall = func() error {
-			resetCalled = true
+		um.RemoveAllCall = func() error {
+			removeAllCalled = true
 			return nil
 		}
 		um.UpdateCall = func(newVer string) {
@@ -89,7 +89,7 @@ func TestVersionChange(t *testing.T) {
 
 		handleVersionChange(service, "")
 
-		tests.H(t).BoolEql(resetCalled, true)
+		tests.H(t).BoolEql(removeAllCalled, true)
 		tests.H(t).BoolEql(updateCalled, false)
 	})
 

--- a/uiService/root_test.go
+++ b/uiService/root_test.go
@@ -178,6 +178,8 @@ type fakeUpdateManager struct {
 	VersionPathError     error
 	ResetError           error
 	ResetCall            func() error
+	RemoveAllError       error
+	RemoveAllCall        func() error
 	UpdateError          error
 	UpdateCall           func(string)
 	UpdateNewVersionPath string
@@ -208,6 +210,17 @@ func (um *fakeUpdateManager) RemoveVersion(version string) error {
 	}
 	if um.ResetCall != nil {
 		tErr := um.ResetCall()
+		return tErr
+	}
+	return nil
+}
+
+func (um *fakeUpdateManager) RemoveAllVersionsExcept(string) error {
+	if um.RemoveAllError != nil {
+		return um.RemoveAllError
+	}
+	if um.RemoveAllCall != nil {
+		tErr := um.RemoveAllCall()
 		return tErr
 	}
 	return nil


### PR DESCRIPTION
Delete orphaned versions of the UI when starting up, resetting, and updating

## Testing

1. set CLUSTER_URL and AUTH_TOKEN
2. docker-compose up
3. run `docker exec -it <update serivice container id> bash` and change to versions-root directory: `cd /opt/mesosphere/active/versions/`
4. update to a new version using `curl -X POST http://localhost:5000/api/v1/update/2.blah.0/`, observe that the old version is removed, the symlink at `/opt/mesosphere/active/dsos-ui-dist` is updated to the new version
5. reset using `curl -X DELETE http://localhost:5000/api/v1/reset/`, observe that all versions are removed and the symlink is pointing to `/opt/mesosphere/active/dcos-ui`
