### PR TITLE
DCOS-50172: load package name from config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ const (
 	defaultZKBasePath         = "/dcos/ui-update"
 	defaultZKAuthInfo         = ""
 	defaultZKZnodeOwner       = ""
+	defaultPackageName        = "dcos-ui"
 	defaultZKSessionTimeout   = 5 * time.Second
 	defaultZKConnectTimeout   = 5 * time.Second
 	defaultZKPollingInterval  = 30 * time.Second
@@ -54,6 +55,7 @@ const (
 	optZKBasePath         = "zk-base-path"
 	optZKAuthInfo         = "zk-auth-info"
 	optZKZnodeOwner       = "zk-znode-owner"
+	optPackageName        = "package-name"
 	optZKSessionTimeout   = "zk-session-timeout"
 	optZKConnectTimeout   = "zk-connect-timeout"
 	optZKPollingInterval  = "zk-poll-int"
@@ -81,6 +83,7 @@ func defineFlags(viper *viper.Viper) (*pflag.FlagSet, error) {
 	fs.String(optZKBasePath, defaultZKBasePath, "The path of the root zookeeper znode.")
 	fs.String(optZKAuthInfo, defaultZKAuthInfo, "Authentication details for zookeeper.")
 	fs.String(optZKZnodeOwner, defaultZKZnodeOwner, "The ZK owner of the base path.")
+	fs.String(optPackageName, defaultPackageName, "The name of the package to update.")
 	fs.Duration(optZKSessionTimeout, defaultZKSessionTimeout, "ZK session timeout.")
 	fs.Duration(optZKConnectTimeout, defaultZKConnectTimeout, "Timeout to establish initial zookeeper connection.")
 	fs.Duration(optZKPollingInterval, defaultZKPollingInterval, "Interval to check zookeeper node for version updates.")
@@ -209,6 +212,11 @@ func (c Config) ZKAuthInfo() string {
 // ZKZnodeOwner is the ZK owner of the base path
 func (c Config) ZKZnodeOwner() string {
 	return c.viper.GetString(optZKZnodeOwner)
+}
+
+// PackageName is the name of the package to update
+func (c Config) PackageName() string {
+	return c.viper.GetString(optPackageName)
 }
 
 // ZKSessionTimeout is the session timeout to ZK

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ func TestDefaultConfig(t *testing.T) {
 		helper.StringEql(defaults.ZKBasePath(), defaultZKBasePath)
 		helper.StringEql(defaults.ZKAuthInfo(), defaultZKAuthInfo)
 		helper.StringEql(defaults.ZKZnodeOwner(), defaultZKZnodeOwner)
+		helper.StringEql(defaults.PackageName(), defaultPackageName)
 		helper.Int64Eql(defaults.ZKSessionTimeout().Nanoseconds(), defaultZKSessionTimeout.Nanoseconds())
 		helper.Int64Eql(defaults.ZKConnectionTimeout().Nanoseconds(), defaultZKConnectTimeout.Nanoseconds())
 		helper.Int64Eql(defaults.ZKPollingInterval().Nanoseconds(), defaultZKPollingInterval.Nanoseconds())
@@ -200,6 +201,14 @@ func TestConfig(t *testing.T) {
 		helper := tests.H(t)
 		helper.IsNil(err)
 		helper.StringEql(cfg.ZKZnodeOwner(), "testOwner")
+	})
+
+	t.Run("sets PackageName from cli arg", func(t *testing.T) {
+		cfg, err := Parse([]string{"--" + optPackageName, "test-name"})
+
+		helper := tests.H(t)
+		helper.IsNil(err)
+		helper.StringEql(cfg.PackageName(), "test-name")
 	})
 
 	t.Run("sets ZKSessionTimeout from cli arg", func(t *testing.T) {

--- a/cosmos/client.go
+++ b/cosmos/client.go
@@ -73,7 +73,7 @@ type PackageDetailResponse struct {
 
 // ListPackageVersions retrieves a list of package versions from Cosmos matching the packageName provided
 func (c *Client) ListPackageVersions(packageName string) (*ListVersionResponse, error) {
-	listVersionReq := ListVersionRequest{IncludePackageVersions: true, PackageName: "dcos-ui"}
+	listVersionReq := ListVersionRequest{IncludePackageVersions: true, PackageName: packageName}
 	body, err := json.Marshal(listVersionReq)
 
 	if err != nil {

--- a/updateManager/client.go
+++ b/updateManager/client.go
@@ -74,7 +74,8 @@ func NewClient(cfg *config.Config) (*Client, error) {
 
 // LoadVersion downloads the given DC/OS UI version to the target directory.
 func (um *Client) loadVersion(version string, targetDirectory string) error {
-	listVersionResp, listErr := um.Cosmos.ListPackageVersions("dcos-ui")
+	pkgName := um.Config.PackageName()
+	listVersionResp, listErr := um.Cosmos.ListPackageVersions(pkgName)
 	if listErr != nil {
 		logrus.WithError(listErr).Error("Cosmos ListPackageVersions request failed")
 		return ErrCosmosRequestFailure
@@ -85,14 +86,14 @@ func (um *Client) loadVersion(version string, targetDirectory string) error {
 		return ErrRequestedVersionNotFound
 	}
 
-	assets, getAssetsErr := um.Cosmos.GetPackageAssets("dcos-ui", version)
+	assets, getAssetsErr := um.Cosmos.GetPackageAssets(pkgName, version)
 	if getAssetsErr != nil {
 		logrus.WithError(listErr).Error("Cosmos GetPackageAssets request failed")
 		return ErrCosmosRequestFailure
 	}
 	logrus.Info("Loading Version: Retrieved package assets from cosmos")
 
-	uiBundleName := cosmos.PackageAssetNameString("dcos-ui-bundle")
+	uiBundleName := cosmos.PackageAssetNameString(pkgName + "-bundle")
 	uiBundleURI, found := assets[uiBundleName]
 	if !found {
 		return ErrUIPackageAssetNotFound


### PR DESCRIPTION
Load package name from config instead of hardcoding to 'dcos-ui'.

Closes DCOS-50172

## Testing

Unit tests should pass and
- Follow readme to export `CLUSTER_URL` and `AUTH_TOKEN` and run `docker-compose up`
- Look for log message `Loading Version: Retrieved package versions from cosmos` and watching th logs, use  [Rodney's node script](https://gist.github.com/TattdCodeMonkey/880c0826e060da007275ad532cf94d94) to update to one of the versions it lists
- Look for log message `Loading Version: Found asset by name`, name should be `dcos-ui-bundle`

## Trade-offs

N/A

## Dependencies

N/A

