### PR TITLE
[DCOS-50944] fix: Make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 main
 coverage.txt
 coverage.xml
-build/
+builds/
 versions/
 dcos-ui-update-service
-application-build-*
+.docker.build.dev*
 testdata/localCosmos/node_modules/
 testdata/localCosmos/package-lock.json
 testdata/docroot/dcos-ui-dist

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -11,9 +11,5 @@ RUN mkdir -p /run/dcos
 ADD . /src
 WORKDIR /src
 
-COPY go.mod .
-COPY go.sum .
-
 RUN go mod download
-RUN go build .
 EXPOSE 5000

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -10,4 +10,10 @@ RUN mkdir -p /run/dcos
 
 ADD . /src
 WORKDIR /src
+
+COPY go.mod .
+COPY go.sum .
+
+RUN go mod download
+RUN go build .
 EXPOSE 5000

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ endif
 
 DOCKERFILE_DEV_SHA := $(shell cat Dockerfile.dev go.mod | $(SHA1) | awk '{ print $$1 }')
 
+.PHONY: start 
+start: ## start all containers defined in docker-compose.yml
+	$(shell docker-compose up)
+
 .PHONY: watchTest 
 watchTest: docker.build.dev
 	$(call inDocker,rerun -v --test)

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ DOCKERFILE_DEV_SHA := $(shell cat Dockerfile.dev go.mod | $(SHA1) | awk '{ print
 
 .PHONY: start 
 start: ## start all containers defined in docker-compose.yml
-	$(shell docker-compose up)
+	docker-compose up
 
 .PHONY: watchTest 
 watchTest: docker.build.dev

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ For example `make test` will run linting and tests and it will run all these com
 
 ### Inside docker
 
-You can run the service inside docker by exporting `$CLUSTER_URL`, `$AUTH_TOKEN` and running `docker-compose up`
+You can run the service inside docker by exporting `$CLUSTER_URL`, `$AUTH_TOKEN` and running `make start`
 
 ```bash
 $ export CLUSTER_URL=<path_to_a_cluster>


### PR DESCRIPTION
## Overview

- Makefile was broken because some spaces were used instead of a tab 🙄 
- I took the additional step of adding `go mod download` & go build to the docker image, and added image invalidation via changes to Dockerfile.dev or go.mod. This will make successive runs of make test/make lint go much faster

## Testing

Try the following commands, with or without env NO_DOCKER=1

`make lint`
`make test`
`make start`

## Trade-offs

Not sure if make build is necessary in Dockerfile.dev 🤔 
